### PR TITLE
Fixed docs for export method

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ This client supports all the API endpoints described in the [Hackpad API documen
     client.revert(padId, revisionId, [callback])
 
 ### export
-    client.export(padId, format, [callback])
+    client.export(padId, revisionId, format, [callback])
 
 `padId` ID of an existing pad
+
+`revisionId` Revision number (default: 'latest')
 
 `format` 'html', 'md', 'txt' (default: 'html')
 


### PR DESCRIPTION
It's just missing the `revisionId` parameter. Caught me off guard when I followed the existing docs on it.

EDIT: Woops. Just realised there's a PR for it #2 (doesn't have a description for revisionId though).
