### PR TITLE
Fix UTF8 mojibake when importing

### DIFF
--- a/lib/hackpad.js
+++ b/lib/hackpad.js
@@ -44,11 +44,12 @@ var Hackpad = (function() {
     console.log(request);
 
     var req = oauth.request(request, function(responseObj) {
-      var response = '';
-      responseObj.on('data', function(chunk) { response += chunk; });
+      var response = [];
+      responseObj.on('data', function(chunk) { response.push(chunk); });
       responseObj.on('end', function () {
+        var result = Buffer.concat(response).toString('utf-8');
         if(responseObj.headers['content-type'].indexOf('application/json') !== -1) {
-          var data = JSON.parse(response);
+          var data = JSON.parse(result);
 
           if(data.error) {
             callback(data.error);
@@ -56,7 +57,7 @@ var Hackpad = (function() {
             callback(null, data);
           }
         } else {
-          callback(null, response);
+          callback(null, result);
         }
       });
     });


### PR DESCRIPTION
Thanks to @yhsiang for pointing out this bug.

The original stringification fails when a chunk falls between two utf-8 octets in the same character.
