### PR TITLE
Make request logging a debug feature

### DIFF
--- a/lib/hackpad.js
+++ b/lib/hackpad.js
@@ -1,6 +1,7 @@
 var oauth = require('oauth-client');
 var querystring = require('querystring');
 var _ = require('underscore');
+var util = require('util');
 
 var Hackpad = (function() {
 
@@ -41,7 +42,7 @@ var Hackpad = (function() {
 
     request.headers = _.extend(request.headers, headers);
 
-    console.log(request);
+    util.debug(request);
 
     var req = oauth.request(request, function(responseObj) {
       var response = '';


### PR DESCRIPTION
I want to be able to use this in production/ci environments to generate reports on hackpad for our organisation, but since the request logs to the console I can't use this.

My proposed solution is to use `util` and log it as `debug`
